### PR TITLE
Fix Typo / Typing Error

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,11 @@ This protocol represents the data model object. as such, it supplies no informat
 
 ```swift
 protocol TKRadarChartDataSource: class {
-    func numberOfStepForRadarChart(radarChart: TKRadarChart) -> Int
-    func numberOfRowForRadarChart(radarChart: TKRadarChart) -> Int
-    func numberOfSectionForRadarChart(radarChart: TKRadarChart) -> Int
+    func numberOfStepForRadarChart(_ radarChart: TKRadarChart) -> Int
+    func numberOfRowForRadarChart(_ radarChart: TKRadarChart) -> Int
+    func numberOfSectionForRadarChart(_ radarChart: TKRadarChart) -> Int
 
-    func titleOfRowForRadarChart(radarChart: TKRadarChart, row: Int) -> String
+    func titleOfRowForRadarChart(_ radarChart: TKRadarChart, row: Int) -> String
     func valueOfSectionForRadarChart(withRow row: Int, section: Int) -> CGFloat
 }
 ```
@@ -92,14 +92,12 @@ This represents the display and behaviour of the TKRadarChart.
 
 ```swift
 protocol TKRadarChartDelegate: class {
+    func colorOfTitleForRadarChart(_ radarChart: TKRadarChart) -> UIColor
+    func colorOfLineForRadarChart(_ radarChart: TKRadarChart) -> UIColor
+    func colorOfFillStepForRadarChart(_ radarChart: TKRadarChart, step: Int) -> UIColor
 
-    func colorOfTitleForRadarChart(radarChart: TKRadarChart) -> UIColor
-    func colorOfLineForRadarChart(radarChart: TKRadarChart) -> UIColor
-    func colorOfFillStepForRadarChart(radarChart: TKRadarChart, step: Int) -> UIColor
-
-    func colorOfSectionFillForRadarChart(radarChart: TKRadarChart, section: Int) -> UIColor
-    func colorOfSectionBorderForRadarChart(radarChart: TKRadarChart, section: Int) -> UIColor
-
+    func colorOfSectionFillForRadarChart(_ radarChart: TKRadarChart, section: Int) -> UIColor
+    func colorOfSectionBorderForRadarChart(_ radarChart: TKRadarChart, section: Int) -> UIColor
 }
 ```
 

--- a/TKRadarChart/TKRadarChart.swift
+++ b/TKRadarChart/TKRadarChart.swift
@@ -74,7 +74,7 @@ public struct TKRadarChartConfig {
                                   minValue: 0,
                                   maxValue: 5,
                                   borderWidth: 4,
-                                  lindWidth: 1,
+                                  lineWidth: 1,
                                   showPoint: false,
                                   showBorder: false,
                                   showBgLine: true,
@@ -90,7 +90,7 @@ public struct TKRadarChartConfig {
     public var maxValue: CGFloat
     
     public var borderWidth: CGFloat
-    public var lindWidth: CGFloat
+    public var lineWidth: CGFloat
     
     public var showPoint: Bool
     public var showBorder: Bool
@@ -105,7 +105,7 @@ public struct TKRadarChartConfig {
                 minValue: CGFloat,
                 maxValue: CGFloat,
                 borderWidth: CGFloat,
-                lindWidth: CGFloat,
+                lineWidth: CGFloat,
                 showPoint: Bool,
                 showBorder: Bool,
                 showBgLine: Bool,
@@ -117,7 +117,7 @@ public struct TKRadarChartConfig {
         self.minValue = minValue
         self.maxValue = maxValue
         self.borderWidth = borderWidth
-        self.lindWidth = lindWidth
+        self.lineWidth = lineWidth
         self.showPoint = showPoint
         self.showBorder = showBorder
         self.showBgLine = showBgLine
@@ -283,7 +283,7 @@ public class TKRadarChart: UIView, TKRadarChartDelegate {
                 let x = centerPoint.x - radius * sin(i * perAngle)
                 let y = centerPoint.y - radius * cos(i * perAngle)
                 path.addLine(to: CGPoint(x: x, y: y))
-                path.lineWidth = configuration.lindWidth
+                path.lineWidth = configuration.lineWidth
                 path.stroke()
             }
         }


### PR DESCRIPTION
Hello! I found two issues.
1. function spec of protocol `TKRadarChartDataSource`, `TKRadarChartDelegate` in README.md is different from real function spec.
2. I feel `lindWidth` is typing error of `lineWidth`.  So I replaced all `lind` to `line`.
Thank you for your great library :)